### PR TITLE
Fix handling of fields containing the colon character

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function parseFields(info) {
     if (!v[0].trim() || v[0].indexOf('db') === 0 ||  v[0].indexOf('cmdstat_') === 0) {
       return m;
     }
-    m[v[0]] = v[1];
+    m[v[0]] = v.slice(1).join(':');
     return m;
   }, {
     databases: parseDatabases(info),

--- a/test/redis-info.test.js
+++ b/test/redis-info.test.js
@@ -11,6 +11,13 @@ describe('redis-info', function () {
       done();
     });
 
+    it('should handle field values containing the colon character', function (done) {
+      var parsedInfo = redis_info.parse('# Server\r\nconfig_file:Y:\\redis\\redis.conf\r\n');
+      t.isObject(parsedInfo);
+      t.equal(parsedInfo.config_file, 'Y:\\redis\\redis.conf');
+      done();
+    });
+
     it('should return an empty DB if the database keys are not defined', function (done) {
       var parser = redis_info.parse("db0\r\n");
       t.deepEqual(parser.databases, {


### PR DESCRIPTION
This super simple PR resolves #21, an issue which occurs when field values containing the colon character are encountered, resulting in unwanted truncation of the resulting value string.

A corresponding test case has been added to ensure correctness.